### PR TITLE
Fix icon url

### DIFF
--- a/growl.py
+++ b/growl.py
@@ -445,10 +445,9 @@ def main():
     name = "WeeChat"
     hostname = weechat.config_get_plugin('hostname')
     password = weechat.config_get_plugin('password')
-    icon = 'file://{0}'.format(
-        os.path.join(
-            weechat.info_get("weechat_dir", ""),
-            weechat.config_get_plugin('icon')))
+    icon = open(os.path.join(
+        weechat.info_get("weechat_dir", ""),
+        weechat.config_get_plugin('icon')), "rb").read()
     notifications = [
         'Public',
         'Private',


### PR DESCRIPTION
URL based images do not work in the OS X version of growl 1.4 and up. This is the suggested fix from gntp.
